### PR TITLE
use -m flag for GitRepo.pdiff() call

### DIFF
--- a/anyvcs/git.py
+++ b/anyvcs/git.py
@@ -214,7 +214,7 @@ class GitRepo(VCSRepo):
     return results
 
   def pdiff(self, rev):
-    cmd = [GIT, 'diff-tree', '-p', '--root', rev]
+    cmd = [GIT, 'diff-tree', '-p', '-m', '--root', rev]
     return self._command(cmd)
 
   def diff(self, rev_a, rev_b, path=None):


### PR DESCRIPTION
Without -m, diff-tree does not show any output for merge commits.

Before merging, you may want to check if "-m" is what we want. It looks like it is to me, but the "-c" flag [by the docs](http://git-scm.com/docs/git-diff-tree) sounded like the right thing to use. "-m" will do a separated side-by-side diff while "-c" will show an interleaved diff. However, it seems like when used on a merge commit which would have been fast-forwarded if --no-ff was not used, it just seems to echo the revision.
