### PR TITLE
fix incorrect HgRepo.ls behavior when given directory flag

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -569,6 +569,16 @@ class BasicTest(object):
     result = self.repo.ls(self.main_branch, '/a', directory=True)
     correct = [{'type':'f'}]
     self.assertEqual(normalize_ls(result), normalize_ls(correct))
+  
+  def test_ls11(self):
+    result = self.repo.ls(self.main_branch, '/c/d', directory=True)
+    correct = [{'type':'d'}]
+    self.assertEqual(normalize_ls(result), normalize_ls(correct))
+
+  def test_ls12(self):
+    result = self.repo.ls(self.main_branch, '/c/d/', directory=True)
+    correct = [{'type':'d'}]
+    self.assertEqual(normalize_ls(result), normalize_ls(correct))
 
   def test_ls_error1(self):
     self.assertRaises(PathDoesNotExist, self.repo.ls, self.main_branch, '/z')


### PR DESCRIPTION
HgRepo.ls appears to have trouble with the `directory` flag. In at least the case where the desired directory is one dir deep, it lists the contents of the directory rather than returning [{'type': 'd'}]
