### PR TITLE
Fix deep path issues

### DIFF
--- a/anyvcs/hg.py
+++ b/anyvcs/hg.py
@@ -30,6 +30,7 @@ import datetime
 import os
 import re
 import subprocess
+import errno
 from .common import *
 
 HG = 'hg'
@@ -64,6 +65,12 @@ class HgRepo(VCSRepo):
     @classmethod
     def clone(cls, srcpath, destpath):
         """Clone an existing repository to a new bare repository."""
+        # Mercurial will not create intermediate directories for clones.
+        try:
+            os.makedirs(destpath)
+        except OSError as e:
+            if not e.errno == errno.EEXIST:
+                raise
         cmd = [HG, 'clone', '--quiet', '--noupdate', srcpath, destpath]
         subprocess.check_call(cmd)
         return cls(destpath)
@@ -87,7 +94,6 @@ class HgRepo(VCSRepo):
         try:
             os.mkdir(path)
         except OSError as e:
-            import errno
             if e.errno != errno.EEXIST:
                 raise
         return path

--- a/anyvcs/svn.py
+++ b/anyvcs/svn.py
@@ -31,6 +31,7 @@ import fnmatch
 import re
 import subprocess
 import sys
+import errno
 from .common import *
 
 DIFF = 'diff'
@@ -84,6 +85,11 @@ class SvnRepo(VCSRepo):
     @classmethod
     def clone(cls, srcpath, destpath):
         """Copy a main repository to a new location."""
+        try:
+            os.makedirs(destpath)
+        except OSError as e:
+            if not e.errno == errno.EEXIST:
+                raise
         cmd = [SVNADMIN, 'dump', '--quiet', '.']
         dump = subprocess.Popen(
                cmd, cwd=srcpath, stdout=subprocess.PIPE,
@@ -131,7 +137,6 @@ class SvnRepo(VCSRepo):
         try:
             os.mkdir(path)
         except OSError as e:
-            import errno
             if e.errno != errno.EEXIST:
                 raise
         return path

--- a/anyvcs/svn.py
+++ b/anyvcs/svn.py
@@ -108,6 +108,11 @@ class SvnRepo(VCSRepo):
     @classmethod
     def create(cls, path):
         """Create a new repository"""
+        try:
+            os.makedirs(path)
+        except OSError as e:
+            if not e.errno == errno.EEXIST:
+                raise
         cmd = [SVNADMIN, 'create', path]
         subprocess.check_call(cmd)
         return cls(path)

--- a/tests.py
+++ b/tests.py
@@ -723,7 +723,7 @@ class BasicTest(object):
         self.assertTrue(os.path.exists(result.path))
         shutil.rmtree(destpath)
 
-    def test_init_deep(self):
+    def test_create_deep(self):
         destpath = os.path.join(tempfile.mktemp(prefix='anyvcs-test-create.'),
                                 'deep',
                                 'path')

--- a/tests.py
+++ b/tests.py
@@ -713,6 +713,16 @@ class BasicTest(object):
         self.assertEqual(commits_expected, commits_actual)
         shutil.rmtree(destpath)
 
+    def test_clone_deep(self):
+        destpath = os.path.join(tempfile.mktemp(prefix='anyvcs-test-clone.'),
+                                'deep',
+                                'path')
+        result = anyvcs.clone(self.repo.path, destpath)
+        self.assertEqual(type(self.repo), type(result))
+        self.assertEqual(destpath, result.path)
+        self.assertTrue(os.path.exists(result.path))
+        shutil.rmtree(destpath)
+
     def test_empty(self):
         result = self.repo.empty()
         correct = False

--- a/tests.py
+++ b/tests.py
@@ -723,6 +723,16 @@ class BasicTest(object):
         self.assertTrue(os.path.exists(result.path))
         shutil.rmtree(destpath)
 
+    def test_init_deep(self):
+        destpath = os.path.join(tempfile.mktemp(prefix='anyvcs-test-create.'),
+                                'deep',
+                                'path')
+        result = anyvcs.create(destpath, self.vcs)
+        self.assertIsInstance(result, anyvcs.common.VCSRepo)
+        self.assertEqual(destpath, result.path)
+        self.assertTrue(os.path.exists(result.path))
+        shutil.rmtree(destpath)
+
     def test_empty(self):
         result = self.repo.empty()
         correct = False


### PR DESCRIPTION
The various VCS types behave differently when you clone to paths whose intermediate directories do not exist. This PR attempts to consolidate that by making everything follow the Git convention to create intermediate paths.

There's a similar problem for `anyvcs.create()` which I've gone ahead and fixed in this PR.
