### PR TITLE
Minimal subrepository tests and implementation

### DIFF
--- a/anyvcs/git.py
+++ b/anyvcs/git.py
@@ -169,6 +169,8 @@ class GitRepo(VCSRepo):
                 entry.type = 'l'
                 if 'target' in report:
                     entry.target = self._cat(rev, ename).decode(self.encoding, 'replace')
+            elif mode == 0o160000:
+                entry.type = 's'
             else:
                 assert False, 'unexpected output: ' + str(line)
             results.append(entry)

--- a/anyvcs/git.py
+++ b/anyvcs/git.py
@@ -170,7 +170,7 @@ class GitRepo(VCSRepo):
                 if 'target' in report:
                     entry.target = self._cat(rev, ename).decode(self.encoding, 'replace')
             elif mode == 0o160000:
-                entry.type = 's'
+                continue
             else:
                 assert False, 'unexpected output: ' + str(line)
             results.append(entry)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -172,7 +172,6 @@ class GitSubmoduleTest(GitTest, common.SubmoduleTest):
         expected = common.normalize_ls([
             {'path': '.gitmodules', 'type': 'f', 'name': '.gitmodules'},
             {'path': 'cats.txt', 'type': 'f', 'name': 'cats.txt'},
-            {'path': 'submodule', 'type': 's', 'name': 'submodule'},
         ])
         self.assertEqual(expected, result)
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -166,5 +166,16 @@ class GitEmptyCommitTest(GitTest, common.EmptyCommitTest):
     pass
 
 
+class GitSubmoduleTest(GitTest, common.SubmoduleTest):
+    def test_ls1(self):
+        result = common.normalize_ls(self.repo.ls(self.working_head, '/'))
+        expected = common.normalize_ls([
+            {'path': '.gitmodules', 'type': 'f', 'name': '.gitmodules'},
+            {'path': 'cats.txt', 'type': 'f', 'name': 'cats.txt'},
+            {'path': 'submodule', 'type': 's', 'name': 'submodule'},
+        ])
+        self.assertEqual(expected, result)
+
+
 if __name__ == "__main__":
     common.unittest.main()

--- a/tests/test_hg.py
+++ b/tests/test_hg.py
@@ -177,5 +177,16 @@ class HgCopyTest(HgTest, common.CopyTest):
     pass
 
 
+class HgSubmoduleTest(HgTest, common.SubmoduleTest):
+    def test_ls1(self):
+        result = common.normalize_ls(self.repo.ls(self.working_head, '/'))
+        expected = common.normalize_ls([
+            {'path': '.hgsub', 'type': 'f', 'name': '.hgsub'},
+            {'path': '.hgsubstate', 'type': 'f', 'name': '.hgsubstate'},
+            {'path': 'cats.txt', 'type': 'f', 'name': 'cats.txt'},
+        ])
+        self.assertEqual(expected, result)
+
+
 if __name__ == "__main__":
     common.unittest.main()

--- a/tests/test_svn.py
+++ b/tests/test_svn.py
@@ -533,5 +533,12 @@ class SvnHeadRevTest(SvnTest):
         self.assertTrue(len(diff) > 0)
 
 
+class SvnSubmoduleTest(SvnTest, common.SubmoduleTest):
+    def test_propget1(self):
+        result = self.repo.propget('svn:externals', self.rev1, '/')
+        expected = 'submodule file://%s\n' % self.main_path
+        self.assertEqual(expected, result)
+
+
 if __name__ == "__main__":
     common.unittest.main()


### PR DESCRIPTION
Currently Git submodules just break VCSRepo.ls right now. This just ignores submodules from ls results with the intent of enabling them in the future with the `report` arg to ls().
