### PR TITLE
Coverage reports in CI builds

### DIFF
--- a/.travis-requirements.sh
+++ b/.travis-requirements.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-set -x
-case "`python --version 2>&1`" in
-  "Python 2.6."*)
-    pip install unittest2
-    ;;
-esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,19 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.2"
-  - "3.3"
 env:
-  - SUITE=
+  global:
+    - SUITE=
+  matrix:
+    - TOXENV=py26
+    - TOXENV=py27
+    - TOXENV=py32
+    - TOXENV=py33
 install:
-  - pip install .
-  - sh ./.travis-requirements.sh
+  - pip install tox
 before_script:
   - git --version
   - hg --version --quiet
   - svn --version --quiet
 script:
-  - export PYTHONPATH=tests TEST_LOG_FILE=`mktemp`; py.test $SUITE -v || (cat $TEST_LOG_FILE; false)
+  - |
+    export TEST_LOG_FILE=`mktemp`
+    tox -v -- -v --cov anyvcs $SUITE || (cat $TEST_LOG_FILE; false)

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_script:
   - git --version
   - hg --version --quiet
   - svn --version --quiet
+  - python --version
 script:
   - |
     export TEST_LOG_FILE=`mktemp`

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,9 @@
 envlist = py26,py27,py32,py33
 
 [testenv]
-deps = pytest
-commands = py.test
+deps =
+    pytest
+    pytest-cov
+commands = py.test --cov anyvcs
 setenv =
     PYTHONPATH = {toxinidir}/tests

--- a/tox.ini
+++ b/tox.ini
@@ -8,3 +8,9 @@ deps =
 commands = py.test []
 setenv =
     PYTHONPATH = {toxinidir}/tests
+
+[testenv:py26]
+deps =
+    pytest
+    pytest-cov
+    unittest2

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,6 @@ envlist = py26,py27,py32,py33
 deps =
     pytest
     pytest-cov
-commands = py.test --cov anyvcs
+commands = py.test []
 setenv =
     PYTHONPATH = {toxinidir}/tests


### PR DESCRIPTION
This adds the possibility of doing coverage testing in our `tox.ini` file. It also switches Travis over to using tox just for consistency.

Originally we thought tox just ran a build matrix which Travis already had so we didn't switch. Tox also manages dependencies for local testing (e.g. the unittest2 for python2.6), and installs from source distribution so it also tests our use of setuptools.
